### PR TITLE
Heading update for SMA

### DIFF
--- a/app/views/SMA-prototype/sma.html
+++ b/app/views/SMA-prototype/sma.html
@@ -29,7 +29,10 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <h1 class="govuk-heading-xl">Spinal Muscular Atrophy (SMA) <span id="type-tag">Adult</span></h1>
+        <h1 class="govuk-heading-xl">
+            <span class="govuk-caption-xl">Adult screening programme</span>
+              Spinal Muscular Atrophy (SMA)
+          </h1>
       </div>
 
       <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
Removed non gov uk 'adult' tag and replaced with gov uk 'caption' pattern. Also added context to classification e.g 'Adult screening programme'.