### PR TITLE
Prototype v5 in carousel

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -32,6 +32,18 @@ router.get('/search_b', function (req, res) {
   })
 })
 
+router.get('/search', function (req, res) {
+  let policies = search.filter(req.query)
+
+  res.render('topup/search', {
+    policies: policies,
+    whoFilter: req.query.who_filter || 'None',
+    statusFilter: req.query.status_filter || 'None',
+    term: req.query.term
+  })
+})
+
+
 router.get('/search_c', function (req, res) {
   var search_c = require('./search_c')
   let policies = search_c.filter(req.query)

--- a/app/views/SMA-prototype/sma.html
+++ b/app/views/SMA-prototype/sma.html
@@ -29,48 +29,34 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <h1 class="govuk-heading-xl">
-            <span class="govuk-caption-xl">Adult screening programme</span>
-              Spinal Muscular Atrophy (SMA)
-          </h1>
+        <h1 class="govuk-heading-xl">Spinal Muscular Atrophy (SMA) <span id="type-tag">Adult</span></h1>
       </div>
 
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-l">Recommendation</h2>
-        <p class="govuk-body govuk-!-font-weight-bold recommendation-badge">
+        <p class="govuk-body govuk-!-font-weight-bold">
           <span id="not-recommended">Screening is not currently recommended for this condition</span>
         </p>
 
-        <p class="govuk-body">
-          Following a review of the evidence against strict criteria, the UK NSC does not currently recommend introducing a national screening programme for carrier or new-born screening for spinal muscular atrophy.
-        </p>
-
-        <p class="govuk-body">
-          Key findings supporting the UK NSC recommendation:
-        </p>
-
-        <ul class="govuk-list govuk-list--bullet">
-         <li>there was very limited evidence about how acceptable a screening programme would be</li>
-         <li>there was no evidence on how to support individuals who need to make difficult decisions following carrier screening</li>
-         <li>there was a lack of information on the reliability of screening tests for SMA</li>
-         <li>no effective treatments for SMA were identified in an unsymptomatic population, currently only palliative support can be offered - however, the review identified evidence on a new treatment for SMA, called nusinersen, that can improve symptoms in children with SMA</li>
-         <li>this evidence review did not find information on the effectiveness of nusinersen in children without symptoms, and there is no evidence on the long term effects of this drug</li>
-        </ul>
-        
-        <h2 class="govuk-heading-l">Review cycle</h2>
-        <p class="govuk-body">Last review completed: 2016</p>
-        <p class="govuk-body">Next review estimated to be completed: 2019 to 2020</p>
-
         <h2 class="govuk-heading-l">More about SMA</h2>
         <p class="govuk-body">
-          Spinal muscular atrophy (SMA) is a genetic disease that causes muscle weakness and a progressive loss of movement. There is no cure but therapy and support are available to help manage the condition.
+          Spinal muscular atrophy (SMA) is a genetic disease that causes muscle weakness and a progressive loss of movement. There are four types of SMA that vary in terms of the age those sufferers develop symptoms and also the severity of the symptoms they can have. There is no cure but therapy and support are available to help manage the condition.
         </p>
-
         <p class="govuk-body">
-          <a href="#" class="govuk-link">Read more on NHS UK</a>
+          SMA causes the motor neurones in a certain area of the spinal cord to deteriorate. This can result in progressive muscle wasting and loss of ability to move parts of the body. SMA is rare, with an estimated 5,500 to 6,000 people with SMA at any one time in the UK.
+        </p>
+        <p class="govuk-body">
+          <a href="#" class="govuk-link">Read more on NHS Choices</a>
         </p>
 
-        <h2 class="govuk-heading-l">Supporting documents</h2>
+        <h2 class="govuk-heading-l">Downloads</h2>
+        <div class="govuk-inset-text">
+          <p>
+            <a class="govuk-link" href="#">Recommendation statement</a>
+            <br>
+            This is a plain english summary of the UK NSC's current recommendation for this condition
+          </p>
+        </div>
         <div class="govuk-inset-text">
           <p>
             <a class="govuk-link" href="#">Last evidence review</a>

--- a/app/views/layout_unbranded_home.html
+++ b/app/views/layout_unbranded_home.html
@@ -23,9 +23,9 @@
   <h2 class="govuk-heading-l" style="margin-top: 50px; margin-bottom: 50px;">End-to-end journey</h2>
 
   <div class="policy-display" style="margin-bottom: 50px;">
-    <img src="/public/images/homepage.png" alt="" style="height: 440px;">
+    <img src="/public/images/topup-work.png" alt="" style="height: 440px;">
       <ul>
-        <li><a href="/end-to-end/homepage.html">Public facing user journey</a></li>
+        <li><a href="/public/images/nsc-homepage.pdf">Public facing user journey</a></li>
         <li><a href="/v4/index.html">Admin facing user journey</a></li>
       </ul>
   </div>

--- a/app/views/layout_unbranded_home.html
+++ b/app/views/layout_unbranded_home.html
@@ -175,11 +175,11 @@
 
   <div class="mySlides fade">
     <div class="policy-display">
-      <img src="/public/images/topup-work.png" style="width:490px; height: 500px;">
+      <img src="/public/images/homepage.png" style="width:490px; height: 500px;">
       <div class="text">
-        <a href="/public/images/nsc-homepage.pdf" class="govuk-link">Updated prototype</a>
+        <a href="/end-to-end/homepage.html" class="govuk-link">Version 5</a>
         <ul>
-          <li>Updated public prototype as a result of topup sprint</li>
+          <li>Prototype end-to-end public facing journey (end-Alpha phase)</li>
         </ul>
       </div>
     </div>

--- a/app/views/search-v1/index_b.html
+++ b/app/views/search-v1/index_b.html
@@ -12,36 +12,41 @@
         Complete list of UK NSC recommendations
       </h1>
 
+      <h2 class="govuk-heading-l">
+        Find a condition
+      </h2>
+
+
       <form method="GET" id="search">
 
         <div class="govuk-form-group">
+          <label class="govuk-label govuk-heading-m" for="term">
+          </label>
           <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-              <label for="term">
-              <h2 class="govuk-fieldset__heading">
-                Find a condition
-              </h2>
-              </label>
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h1 class="govuk-fieldset__heading">
+                Search for conditions
+              </h1>
             </legend>
 
             <input class="govuk-input" id="term" name="term" type="text"
                    value="{{ term }}" style="width: 80%">
-            <button type="submit" class="govuk-button search-b-button">
+            <button type="submit" class="govuk-button">
               Search
             </button>
-            <a href="/search_b?term=&who_filter=None&status_filter=None" class="govuk-link govuk-link--no-visited-state">Clear search</a>
           </fieldset>
         </div>
 
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="who_filter_hint">
+            <span id="who_filter_hint" class="govuk-hint"></span>
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-              <h2 class="govuk-fieldset__heading">
+              <h1 class="govuk-fieldset__heading">
                 Based on who the condition affects
-              </h2>
+              </h1>
             </legend>
 
-            <div class="govuk-radios govuk-radios">
+            <div class="govuk-radios govuk-radios--inline">
               {% for who in ["Antenatal", "Newborn", "Child", "Adult",  "None" ] %}
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="who_filter_{{who}}"
@@ -54,18 +59,20 @@
               </div>
               {% endfor %}
             </div>
+
           </fieldset>
         </div>
 
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="status_filter_hint">
+            <span id="status_filter_hint" class="govuk-hint"></span>
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-              <h2 class="govuk-fieldset__heading">
+              <h1 class="govuk-fieldset__heading">
                 Based on the current recommendation status
-              </h2>
+              </h1>
             </legend>
 
-            <div class="govuk-radios govuk-radios">
+            <div class="govuk-radios govuk-radios--inline">
               {% for status, value in {"Yes": "Yes", "No": "No,Nice,Nsc", "None": "None" } %}
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="status_filter_{{ status }}"
@@ -80,37 +87,21 @@
             </div>
           </fieldset>
         </div>
+
+
       </form>
 
       <table class="govuk-table">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th class="govuk-table__header" scope="col">Condition</th>
-            <th class="govuk-table__header" scope="col">Affects</th>
-            <th class="govuk-table__header" scope="col">Systematic Population Screening</th>
-          </tr>
-        </thead>
         <tbody class="govuk-table__body">
-          {% for policy in policies %}
-            <tr class="govuk-table__row">
-              {% if policy.Recommendation === "Recommended" %}
-                {% set status_class = "status__recommended" %}
-              {% else %}
-                {% set status_class = "status__not-recommended" %}
-              {% endif %}
-
-              {% if policy.Condition === "SMA" %}
-                <td class="govuk-table__cell"><a href="/SMA-prototype/sma">{{ policy.Condition }}</a></td>
-              {% else %}
-                <td class="govuk-table__cell"><a href="#">{{ policy.Condition }}</a></td>
-              {% endif %}
-
-              <td class="govuk-table__cell">{{ policy.Type }}</td>
-              <td class="govuk-table__cell "><span class="{{status_class}}">{{ policy.Recommendation }}</span></td>
-            </tr>
-          {% else %}
-            <p>No Policies</p>
-          {% endfor %}
+        {% for policy in policies %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><a href="https://legacyscreening.phe.org.uk/{{ policy.URL }}" target="_blank">{{ policy.Condition }}</a></td>
+            <td class="govuk-table__cell">{{ policy.Type }}</td>
+            <td class="govuk-table__cell">{{ policy.Recommendation }}</td>
+          </tr>
+        {% else %}
+          <p>No Policies</p>
+        {% endfor %}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
Named the end-alpha public facing prototype "v5" and placed it in the carousel.

Also, linked to the new top up versions at the top of the prototype home page. Note that this does not display as many pages as v5 (e.g. the consultation page) as yet. 

### UI changes

![saved_page](https://user-images.githubusercontent.com/1370570/57850898-0e1d8380-77d7-11e9-8453-53cae4764a32.png)
