### PR TITLE
Removed gov uk font override snippet from unbranded.css

### DIFF
--- a/app/assets/sass/unbranded.scss
+++ b/app/assets/sass/unbranded.scss
@@ -1,8 +1,5 @@
 @import "node_modules/govuk-frontend/settings/all";
 
-// Override the govuk-frontend font stack
-$govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
-
 // Remove canvas background colour, as is used with the GOV.UK Footer.
 $govuk-canvas-background-colour: $govuk-body-background-colour;
 


### PR DESCRIPTION
Now everything will be transport new font – including homepage